### PR TITLE
feat(Profile): 프로필 이미지 조회 및 수정 기능 추가

### DIFF
--- a/src/main/java/backend/profile/controller/ProfileController.java
+++ b/src/main/java/backend/profile/controller/ProfileController.java
@@ -1,0 +1,68 @@
+package backend.profile.controller;
+
+import backend.profile.dto.UpdateProfileRequest;
+import backend.profile.dto.UserProfileResponse;
+import backend.profile.service.ProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/profile")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    /**
+     * 내 프로필 조회
+     */
+    @GetMapping
+    public ResponseEntity<UserProfileResponse> getMyProfile(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        try {
+            UserProfileResponse profile = profileService.getMyProfile(userDetails.getUsername());
+            log.info("프로필 조회 성공: userId={}", userDetails.getUsername());
+            return ResponseEntity.ok(profile);
+        } catch (Exception e) {
+            log.error("프로필 조회 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 내 프로필 수정
+     */
+    @PutMapping
+    public ResponseEntity<UserProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        try {
+            UserProfileResponse updated = profileService.updateMyProfile(userDetails.getUsername(), request);
+            log.info("프로필 수정 성공: userId={}, nickname={}", userDetails.getUsername(), request);
+            return ResponseEntity.ok(updated);
+        } catch (IllegalArgumentException e) {
+            log.warn("프로필 수정 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("프로필 수정 중 오류: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}
+
+

--- a/src/main/java/backend/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/backend/profile/dto/UpdateProfileRequest.java
@@ -1,0 +1,17 @@
+package backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequest {
+    @NotBlank(message = "avatarUrl은 필수입니다")
+    private String avatarUrl;
+}
+

--- a/src/main/java/backend/profile/dto/UserProfileResponse.java
+++ b/src/main/java/backend/profile/dto/UserProfileResponse.java
@@ -1,0 +1,16 @@
+package backend.profile.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileResponse {
+    private String userId;
+    private String avatarUrl;
+}
+

--- a/src/main/java/backend/profile/service/ProfileService.java
+++ b/src/main/java/backend/profile/service/ProfileService.java
@@ -1,0 +1,45 @@
+package backend.profile.service;
+
+import backend.profile.dto.UpdateProfileRequest;
+import backend.profile.dto.UserProfileResponse;
+import backend.user.domain.User;
+import backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 프로필 조회
+     */
+    public UserProfileResponse getMyProfile(String userId) throws Exception {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        return UserProfileResponse.builder()
+                .userId(user.getUserId())
+                .avatarUrl(user.getAvatarUrl())
+                .build();
+    }
+
+    /**
+     * 프로필 수정 (닉네임/소개)
+     */
+    @Transactional
+    public UserProfileResponse updateMyProfile(String userId, UpdateProfileRequest request) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        user.updateAvatar(request.getAvatarUrl());
+        userRepository.save(user);
+        return UserProfileResponse.builder()
+                .userId(user.getUserId())
+                .avatarUrl(user.getAvatarUrl())
+                .build();
+    }
+}
+


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 주요 변경 사항
> 어떤 기능을 추가/수정했는지 간단하고 명확하게 설명해주세요.

feat(Profile): 프로필 이미지 API 구현
- DTO: UpdateProfileRequest, UserProfileResponse 추가
- 컨트롤러: 프로필 이미지 조회/수정 엔드포인트 구현
- 서비스: 기본 이미지 반환 및 사용자 이미지 업데이트 로직 구현

---

## 🛠 작업 상세 내용
| 항목 | 내용 |
|------|------|
| 구현 기능 | ex: 사용자 프로필 조회, 수정 기능 구현 |
| 추가 패키지 | ex: axios, styled-components |
| 수정한 파일 | `UpdateProfileRequest, UserProfileResponse, ProfileController, ProfileService` |

---

## ✅ 체크리스트
- [x] 기능이 정상 동작함

---


## 💬 기타 참고 사항
- 리뷰어가 알고 있으면 좋을 내용, 주의사항 등을 자유롭게 작성해주세요.