### PR TITLE
feat(Profile): 프로필 이미지 조회 및 수정 기능 추가

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -16,7 +16,7 @@ reviews:
     base_branches:
       - "main"
       - "develop"
-      - "master"
+
 
 # 채팅 설정
 chat:

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -5,7 +5,7 @@ early_access: false
 # 리뷰 설정
 reviews:
   profile: "assertive"  # 더 상세한 코드 리뷰를 위해 assertive로 변경
-  request_changes_workflow: false  # PR 자동 승인 비활성화로 수동 검토 강제
+  request_changes_workflow: true  # PR 자동 승인 비활성화로 수동 검토 강제
   high_level_summary: true
   poem: false  # 시 생성 비활성화
   review_status: true

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -16,6 +16,7 @@ reviews:
     base_branches:
       - "main"
       - "develop"
+      - "user/profile"
 
 
 # 채팅 설정

--- a/src/main/java/backend/profile/controller/ProfileController.java
+++ b/src/main/java/backend/profile/controller/ProfileController.java
@@ -28,11 +28,14 @@ public class ProfileController {
         if (userDetails == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        
+
         try {
             UserProfileResponse profile = profileService.getMyProfile(userDetails.getUsername());
             log.info("프로필 조회 성공: userId={}", userDetails.getUsername());
             return ResponseEntity.ok(profile);
+        } catch (IllegalArgumentException e) {
+            log.warn("프로필 조회 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (Exception e) {
             log.error("프로필 조회 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
@@ -53,7 +56,7 @@ public class ProfileController {
         
         try {
             UserProfileResponse updated = profileService.updateMyProfile(userDetails.getUsername(), request);
-            log.info("프로필 수정 성공: userId={}, nickname={}", userDetails.getUsername(), request);
+            log.info("프로필 수정 성공: userId={}, avatarUrl={}", userDetails.getUsername(), request);
             return ResponseEntity.ok(updated);
         } catch (IllegalArgumentException e) {
             log.warn("프로필 수정 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());

--- a/src/main/java/backend/profile/controller/ProfileController.java
+++ b/src/main/java/backend/profile/controller/ProfileController.java
@@ -1,0 +1,68 @@
+package backend.profile.controller;
+
+import backend.profile.dto.UpdateProfileRequest;
+import backend.profile.dto.UserProfileResponse;
+import backend.profile.service.ProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/profile")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    /**
+     * 내 프로필 조회
+     */
+    @GetMapping
+    public ResponseEntity<UserProfileResponse> getMyProfile(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        try {
+            UserProfileResponse profile = profileService.getMyProfile(userDetails.getUsername());
+            log.info("프로필 조회 성공: userId={}", userDetails.getUsername());
+            return ResponseEntity.ok(profile);
+        } catch (Exception e) {
+            log.error("프로필 조회 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 내 프로필 수정
+     */
+    @PutMapping
+    public ResponseEntity<UserProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        try {
+            UserProfileResponse updated = profileService.updateMyProfile(userDetails.getUsername(), request);
+            log.info("프로필 수정 성공: userId={}, nickname={}", userDetails.getUsername(), request);
+            return ResponseEntity.ok(updated);
+        } catch (IllegalArgumentException e) {
+            log.warn("프로필 수정 실패: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("프로필 수정 중 오류: userId={}, error={}", userDetails.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}
+
+

--- a/src/main/java/backend/profile/dto/UpdateProfileRequest.java
+++ b/src/main/java/backend/profile/dto/UpdateProfileRequest.java
@@ -1,0 +1,17 @@
+package backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequest {
+    @NotBlank(message = "avatarUrl은 필수입니다")
+    private String avatarUrl;
+}
+

--- a/src/main/java/backend/profile/dto/UserProfileResponse.java
+++ b/src/main/java/backend/profile/dto/UserProfileResponse.java
@@ -1,0 +1,16 @@
+package backend.profile.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileResponse {
+    private String userId;
+    private String avatarUrl;
+}
+

--- a/src/main/java/backend/profile/service/ProfileService.java
+++ b/src/main/java/backend/profile/service/ProfileService.java
@@ -18,7 +18,7 @@ public class ProfileService {
     /**
      * 프로필 조회
      */
-    public UserProfileResponse getMyProfile(String userId) throws Exception {
+    public UserProfileResponse getMyProfile(String userId){
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
         return UserProfileResponse.builder()
@@ -28,14 +28,13 @@ public class ProfileService {
     }
 
     /**
-     * 프로필 수정 (닉네임/소개)
+     * 프로필 수정 (아바타 이미지 수정)
      */
     @Transactional
     public UserProfileResponse updateMyProfile(String userId, UpdateProfileRequest request) {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
         user.updateAvatar(request.getAvatarUrl());
-        userRepository.save(user);
         return UserProfileResponse.builder()
                 .userId(user.getUserId())
                 .avatarUrl(user.getAvatarUrl())

--- a/src/main/java/backend/profile/service/ProfileService.java
+++ b/src/main/java/backend/profile/service/ProfileService.java
@@ -1,0 +1,45 @@
+package backend.profile.service;
+
+import backend.profile.dto.UpdateProfileRequest;
+import backend.profile.dto.UserProfileResponse;
+import backend.user.domain.User;
+import backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 프로필 조회
+     */
+    public UserProfileResponse getMyProfile(String userId) throws Exception {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        return UserProfileResponse.builder()
+                .userId(user.getUserId())
+                .avatarUrl(user.getAvatarUrl())
+                .build();
+    }
+
+    /**
+     * 프로필 수정 (닉네임/소개)
+     */
+    @Transactional
+    public UserProfileResponse updateMyProfile(String userId, UpdateProfileRequest request) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        user.updateAvatar(request.getAvatarUrl());
+        userRepository.save(user);
+        return UserProfileResponse.builder()
+                .userId(user.getUserId())
+                .avatarUrl(user.getAvatarUrl())
+                .build();
+    }
+}
+


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 주요 변경 사항
> 어떤 기능을 추가/수정했는지 간단하고 명확하게 설명해주세요.

feat(Profile): 프로필 이미지 API 구현
- DTO: UpdateProfileRequest, UserProfileResponse 추가
- 컨트롤러: 프로필 이미지 조회/수정 엔드포인트 구현
- 서비스: 기본 이미지 반환 및 사용자 이미지 업데이트 로직 구현

---

## 🛠 작업 상세 내용
| 항목 | 내용 |
|------|------|
| 구현 기능 | ex: 사용자 프로필 조회, 수정 기능 구현 |
| 추가 패키지 | ex: axios, styled-components |
| 수정한 파일 | `UpdateProfileRequest, UserProfileResponse, ProfileController, ProfileService` |

---

## ✅ 체크리스트
- [x] 기능이 정상 동작함

---


## 💬 기타 참고 사항
- 리뷰어가 알고 있으면 좋을 내용, 주의사항 등을 자유롭게 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 내 프로필 조회 기능 추가(인증 사용자 대상).
  * 내 프로필 수정 기능 추가(아바타 URL 변경 가능).
  * 응답에 사용자 식별자 및 아바타 URL 포함.

* **버그 수정 / 품질**
  * 입력값 유효성 검사 추가 및 한글 에러 메시지 제공.

* **작업**
  * PR 검토 프로세스 강화(수동 검토 활성화) 및 기본 브랜치 설정 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->